### PR TITLE
fix: add missing parameters for README generator action

### DIFF
--- a/github-actions/generate-and-commit-oss-readme/action.yml
+++ b/github-actions/generate-and-commit-oss-readme/action.yml
@@ -8,6 +8,12 @@ inputs:
   project_stability:
     required: true
     description: 'experimental, alpha, beta, stable'
+  project_type:
+    required: true
+    description: 'sdk, other'
+  sdk_language:
+    required: false
+    description: 'JavaScript, Python, etc.'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
Prior to this commit we had added support for some new parameters
(project_type, sdk_language) for the README generator in the
implementation code.  However, we forgot to add them to the action
definition yaml, which causes failures to consume it from downstream
repos in some cases.
