### PR TITLE
fix: The URL to info about README generation was broken.

### DIFF
--- a/github-actions/oss-readme-template/__tests__/readme.test.ts
+++ b/github-actions/oss-readme-template/__tests__/readme.test.ts
@@ -73,8 +73,8 @@ For more info, visit our website at [https://gomomento.com](https://gomomento.co
       });
     })
       .toThrowError(`README template does not conform to Momento OSS requirements:
-{"lineNumber":2,"ruleNames":["must-include-oss-headers"],"ruleDescription":"Template must begin with OSS Header and end with OSS Footer","ruleInformation":"https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator","errorDetail":"Expected template file to begin with {{ ossHeader }}, on a line by itself.","errorContext":null,"errorRange":null,"fixInfo":null}
-{"lineNumber":2,"ruleNames":["must-include-oss-headers"],"ruleDescription":"Template must begin with OSS Header and end with OSS Footer","ruleInformation":"https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator","errorDetail":"Expected template file to end with {{ ossFooter }}, on a line by itself.","errorContext":null,"errorRange":null,"fixInfo":null}`);
+{"lineNumber":2,"ruleNames":["must-include-oss-headers"],"ruleDescription":"Template must begin with OSS Header and end with OSS Footer","ruleInformation":"https://github.com/momentohq/standards-and-practices/tree/main/github-actions/oss-readme-template","errorDetail":"Expected template file to begin with {{ ossHeader }}, on a line by itself.","errorContext":null,"errorRange":null,"fixInfo":null}
+{"lineNumber":2,"ruleNames":["must-include-oss-headers"],"ruleDescription":"Template must begin with OSS Header and end with OSS Footer","ruleInformation":"https://github.com/momentohq/standards-and-practices/tree/main/github-actions/oss-readme-template","errorDetail":"Expected template file to end with {{ ossFooter }}, on a line by itself.","errorContext":null,"errorRange":null,"fixInfo":null}`);
   });
 
   const VALID_TEMPLATE_CONTENTS = fs

--- a/github-actions/oss-readme-template/dist/index.js
+++ b/github-actions/oss-readme-template/dist/index.js
@@ -99,7 +99,7 @@ exports.mustIncludeOssHeaders = {
     names: ['must-include-oss-headers'],
     description: 'Template must begin with OSS Header and end with OSS Footer',
     tags: ['momento-oss'],
-    information: new URL('https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator'),
+    information: new URL('https://github.com/momentohq/standards-and-practices/tree/main/github-actions/oss-readme-template'),
     function: (params, onError) => {
         const firstThreeTokens = params.tokens.slice(0, 3);
         verifyTokens(firstThreeTokens, ossHeaderTag, onError, 'Expected template file to begin with', firstThreeTokens[0].lineNumber);
@@ -149,7 +149,7 @@ exports.verifySdkSectionHeaders = {
     names: ['expected-sdk-section-headers'],
     description: 'SDK must have required section headers',
     tags: ['momento-oss'],
-    information: new URL('https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator'),
+    information: new URL('https://github.com/momentohq/standards-and-practices/tree/main/github-actions/oss-readme-template'),
     function: (params, onError) => {
         const headers = [];
         let insideHeaderOpenTag = false;

--- a/github-actions/oss-readme-template/src/markdownlint-rules/must-include-oss-headers.ts
+++ b/github-actions/oss-readme-template/src/markdownlint-rules/must-include-oss-headers.ts
@@ -14,7 +14,7 @@ export const mustIncludeOssHeaders: markdownlint.Rule = {
   description: 'Template must begin with OSS Header and end with OSS Footer',
   tags: ['momento-oss'],
   information: new URL(
-    'https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator'
+      'https://github.com/momentohq/standards-and-practices/tree/main/github-actions/oss-readme-template'
   ),
   function: (params, onError) => {
     const firstThreeTokens = params.tokens.slice(0, 3);

--- a/github-actions/oss-readme-template/src/markdownlint-rules/verify-sdk-section-headers.ts
+++ b/github-actions/oss-readme-template/src/markdownlint-rules/verify-sdk-section-headers.ts
@@ -14,7 +14,7 @@ export const verifySdkSectionHeaders: markdownlint.Rule = {
   description: 'SDK must have required section headers',
   tags: ['momento-oss'],
   information: new URL(
-    'https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator'
+    'https://github.com/momentohq/standards-and-practices/tree/main/github-actions/oss-readme-template'
   ),
   function: (params, onError) => {
     const headers: Array<HeaderWithLineNumber> = [];


### PR DESCRIPTION
```
Error: README template does not conform to Momento OSS requirements:
{"lineNumber":45,"ruleNames":["expected-sdk-section-headers"],"ruleDescription":"SDK must have required section headers","ruleInformation":"https://github.com/momentohq/standards-and-practices/github-actions/oss-readme-generator","errorDetail":"After header 'Requirements', missing expected header: 'Examples'","errorContext":null,"errorRange":null,"fixInfo":null}
```

That link is broken.