### PR TITLE
fix: Commit the README even if it didn't already exist.

### DIFF
--- a/github-actions/generate-and-commit-oss-readme/action.yml
+++ b/github-actions/generate-and-commit-oss-readme/action.yml
@@ -45,7 +45,3 @@ runs:
         # Optional commit user and author settings
         commit_user_name: Momento GitHub Actions Bot
         commit_user_email: github-actions-bot@momenthohq.com
-
-        # Optional. Option used by `git-status` to determine if the repository is
-        # dirty. See https://git-scm.com/docs/git-status#_options
-        status_options: '--untracked-files=no'


### PR DESCRIPTION
If the repo didn't already have a README, the generated README is untracked.  git-auto-commit-action will run `git status --untracked-files=no` (which ignores untracked files) to check for changes, think there are no changes, and not do anything. [It won't add the requested files if it thinks the repo is clean](https://github.com/stefanzweifel/git-auto-commit-action/blob/976f22029fe5ee84057c18c4807b8c727952a393/entrypoint.sh#L14).

See https://github.com/momentohq/client-sdk-ruby/actions/runs/3597047740/jobs/6058398212 for the action failure.