### PR TITLE
fix: Make generate-and-commit-oss-readme take the same args as oss-readme-template.

### DIFF
--- a/github-actions/generate-and-commit-oss-readme/action.yml
+++ b/github-actions/generate-and-commit-oss-readme/action.yml
@@ -2,18 +2,26 @@ name: 'Momento OSS README generator'
 description: 'Processes a README template for a Momento SDK, inserts standardized header etc., and commits'
 author: 'Momento'
 inputs:
+  project_type:
+    required: true
+    description: 'sdk or other'
+  sdk_language:
+    required: false
+    description: 'JavaScript, Python, etc.'
   project_status:
     required: true
     description: 'official or incubating'
   project_stability:
     required: true
-    description: 'experimental, alpha, beta, stable'
-  project_type:
-    required: true
-    description: 'sdk, other'
-  sdk_language:
+    description: 'experimental, alpha, beta, or stable'
+  template_file:
     required: false
-    description: 'JavaScript, Python, etc.'
+    description: 'path to readme template file'
+    default: 'README.template.md'
+  output_file:
+    required: false
+    description: 'output file path to write generated README'
+    default: 'README.md'
   usage_example_path:
     required: false
     description: 'path to usage example file'
@@ -22,11 +30,14 @@ runs:
   steps:
     - uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
       with:
-        project_status: "${{  inputs.project_status }}"
-        project_stability: "${{ inputs.project_stability }}"
         project_type: "${{ inputs.project_type }}"
         sdk_language: "${{ inputs.sdk_language }}"
+        project_status: "${{  inputs.project_status }}"
+        project_stability: "${{ inputs.project_stability }}"
+        template_file: "${{ inputs.template_file }}"
+        output_file: "${{ inputs.output_file }}"
         usage_example_path: "${{ inputs.usage_example_path }}"
+
     - shell: bash
       run: |
         git status


### PR DESCRIPTION
It was missing template_file and output_file.

This is causing a commit loop in client-sdk-go.