### PR TITLE
fix: use node v16 in builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: diagnostic
-        run: |
-          npm --version
-          node --version
      - working-directory: ./github-actions/${{ matrix.github-action }}
         run: |
           npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,15 @@ jobs:
         github-action: [ oss-readme-template ]
 
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: diagnostic
         run: |
           npm --version
           node --version
-      - uses: actions/checkout@v2
-      - working-directory: ./github-actions/${{ matrix.github-action }}
+     - working-directory: ./github-actions/${{ matrix.github-action }}
         run: |
           npm install
       - working-directory: ./github-actions/${{ matrix.github-action }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
         github-action: [ oss-readme-template ]
 
     steps:
+      - name: diagnostic
+        run: |
+          npm --version
+          node --version
       - uses: actions/checkout@v2
       - working-directory: ./github-actions/${{ matrix.github-action }}
         run: |


### PR DESCRIPTION
Use LTS Node.js in GitHub actions to avoid this error: https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported