### PR TITLE
chore: bump github action dependencies to latest majors

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         source-root: ./github-actions/${{ matrix.github-action }}/src
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/github-actions/error-email-action/action.yml
+++ b/github-actions/error-email-action/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: dawidd6/action-send-mail@v3
+    - uses: dawidd6/action-send-mail@v16
       with:
         # Required mail server address:
         server_address: smtp.gmail.com
@@ -23,7 +23,7 @@ runs:
         # Required recipients' addresses:
         to: eng-deveco@momentohq.com
         # Required sender full name (address can be skipped):
-        from: Momento OSS
+        from: Momento OSS <github-actions@momentohq.com>
         # Optional whether this connection use TLS (default is true if server_port is 465)
         secure: true
         # Optional plain body:

--- a/github-actions/generate-and-commit-oss-readme/action.yml
+++ b/github-actions/generate-and-commit-oss-readme/action.yml
@@ -50,7 +50,7 @@ runs:
       run: |
         git status
         cat README.md
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: Update templated README.md file
 

--- a/github-actions/shared-build/action.yml
+++ b/github-actions/shared-build/action.yml
@@ -7,6 +7,6 @@ runs:
   steps:
     # Please look up the latest version from
     # https://github.com/amannn/action-semantic-pull-request/releases
-    - uses: amannn/action-semantic-pull-request@v3.4.5
+    - uses: amannn/action-semantic-pull-request@v6
       with:
         validateSingleCommit: true


### PR DESCRIPTION
## Summary

- Bump `amannn/action-semantic-pull-request` from v3.4.5 to v6 (fixes `set-output` deprecation warning)
- Bump `dawidd6/action-send-mail` from v3 to v16 (update `from` field format for v12+ compatibility)
- Bump `stefanzweifel/git-auto-commit-action` from v4 to v7
- Bump `github/codeql-action` (init, autobuild, analyze) from v2 to v4

All inputs used by our actions were verified to still be supported in the new major versions. The only functional change is the `from` field in the error email action, updated from `Momento OSS` to `Momento OSS <github-actions@momentohq.com>` to satisfy the stricter format requirement introduced in send-mail v12.